### PR TITLE
Add MediaTimeRangesType for playback skip or other function

### DIFF
--- a/TVMediaPlayer.xcodeproj/project.pbxproj
+++ b/TVMediaPlayer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BFF05C52058B4EB00A21C94 /* MediaTimeRangesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF05C42058B4EB00A21C94 /* MediaTimeRangesType.swift */; };
 		711F134E1C40F7ED0096DBAD /* TVMediaPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 711F134D1C40F7ED0096DBAD /* TVMediaPlayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711F135A1C40F9560096DBAD /* ControlsOverlay.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 711F13551C40F9560096DBAD /* ControlsOverlay.storyboard */; };
 		711F135B1C40F9560096DBAD /* ControlsOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F13561C40F9560096DBAD /* ControlsOverlayViewController.swift */; };
@@ -52,6 +53,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5BFF05C42058B4EB00A21C94 /* MediaTimeRangesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTimeRangesType.swift; sourceTree = "<group>"; };
 		711F134A1C40F7ED0096DBAD /* TVMediaPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TVMediaPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		711F134D1C40F7ED0096DBAD /* TVMediaPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TVMediaPlayer.h; sourceTree = "<group>"; };
 		711F134F1C40F7ED0096DBAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				711F13571C40F9560096DBAD /* MediaPlayerViewController.swift */,
 				711F13581C40F9560096DBAD /* MediaItemType.swift */,
 				711F13591C40F9560096DBAD /* MediaPlayerType.swift */,
+				5BFF05C42058B4EB00A21C94 /* MediaTimeRangesType.swift */,
 				711F134D1C40F7ED0096DBAD /* TVMediaPlayer.h */,
 				711F134F1C40F7ED0096DBAD /* Info.plist */,
 				711F13651C41C2900096DBAD /* Images.xcassets */,
@@ -263,6 +266,7 @@
 				711F135D1C40F9560096DBAD /* MediaItemType.swift in Sources */,
 				711F135C1C40F9560096DBAD /* MediaPlayerViewController.swift in Sources */,
 				711F135B1C40F9560096DBAD /* ControlsOverlayViewController.swift in Sources */,
+				5BFF05C52058B4EB00A21C94 /* MediaTimeRangesType.swift in Sources */,
 				711F135E1C40F9560096DBAD /* MediaPlayerType.swift in Sources */,
 				711F136A1C41C64D0096DBAD /* PlayerState.swift in Sources */,
 				711F13691C41C64D0096DBAD /* DPadState.swift in Sources */,

--- a/TVMediaPlayer/MediaTimeRangesType.swift
+++ b/TVMediaPlayer/MediaTimeRangesType.swift
@@ -1,0 +1,26 @@
+import Foundation
+import CoreMedia
+
+public protocol MediaTimeRangesType {
+
+    func containsTime(_ time: CMTime) -> CMTimeRange?
+
+    /// The list of ranges
+    var ranges:[CMTimeRange] { get }
+}
+
+public extension MediaTimeRangesType {
+    func containsTime(_ time: CMTime) -> CMTimeRange? {
+        for range in ranges {
+            if (range.containsTime(time)) {
+                return range
+            }
+        }
+        return nil
+    }
+}
+
+//
+//  Created by Martin Glass on 13-Mar-18.
+//  Copyright © 2018 SwiftBit. All rights reserved.
+//

--- a/TVMediaPlayerTestApp/TestMediaPlayer.swift
+++ b/TVMediaPlayerTestApp/TestMediaPlayer.swift
@@ -2,7 +2,7 @@ import Foundation
 import TVMediaPlayer
 import AVFoundation
 
-class TestMediaPlayer: MediaPlayerType, MediaItemType {
+class TestMediaPlayer: MediaPlayerType, MediaItemType, MediaTimeRangesType {
     
     lazy var playerItem:AVPlayerItem = {
         let url = URL(string: "https://download.blender.org/durian/trailer/sintel_trailer-1080p.mp4")!
@@ -14,6 +14,14 @@ class TestMediaPlayer: MediaPlayerType, MediaItemType {
         player.addPeriodicTimeObserver(forInterval: CMTime(value: 10, timescale: 1000), queue: nil) { [weak self] time in
             guard let sself = self else { return }
             let position = time.seconds / sself.length
+            sself.positionChanged?(Float(position))
+        }
+        // skip
+        player.addPeriodicTimeObserver(forInterval: CMTime(value: 1, timescale: 1), queue: nil) { [weak self] time in
+            guard let sself = self else { return }
+            guard let timeRange = sself.containsTime(time) else { return }
+            player.seek(to: timeRange.end)
+            let position = timeRange.end.seconds / sself.length
             sself.positionChanged?(Float(position))
         }
         return player
@@ -61,6 +69,12 @@ class TestMediaPlayer: MediaPlayerType, MediaItemType {
     var subtitle:String? { return "Subtitle" }
     
     var length:Double { return playerItem.duration.seconds }
+    
+    //test range
+    var ranges:[CMTimeRange] {
+        return [CMTimeRange(start:CMTime(seconds:5.000, preferredTimescale:1000),
+                            end:CMTime(seconds:9.000, preferredTimescale:1000))]
+    }
 }
 
 //


### PR DESCRIPTION
This isn't much to work with, but I'm hoping it will start the ball rolling on getting commercial skip working on MythTV on AppleTV.
The API for commercial breaks is at: [/Dvr/GetRecordedCommBreak?RecordedId=_00000_&OffsetType=Duration](url) (valid for MythTV 0.28+)
The XML format returned is given at [https://www.mythtv.org/wiki/DVR_Service#GetRecordedSeek](https://www.mythtv.org/wiki/DVR_Service#GetRecordedSeek).
The `Cutting/Mark` values of `4` (Commercial Start) and `5` (Commercial End); as given at [https://code.mythtv.org/doxygen/programtypes_8h_source.html#l00061](https://code.mythtv.org/doxygen/programtypes_8h_source.html)
The `Cutting/Offset` values are in microseconds, and so translate pretty easily into `CMTime` and `CMTimeRange` values.
